### PR TITLE
Remove MAS update

### DIFF
--- a/update_system
+++ b/update_system
@@ -18,8 +18,3 @@ echo "Running bitrise stepenv update" && \
 $BITRISE_PATH "stepman" "update" && \
 echo "Running bitrise plugin update" && \
 $BITRISE_PATH "plugin" "update"
-
-# MAS upgrade
-MAS_PATH="${BREW_PATH}/bin/mas"
-
-$MAS_PATH "upgrade"


### PR DESCRIPTION
MAS relies on the version code bundled into the app's Info.plist that is (then) compared with the Store version. Many developers do not keep these values correctly matching, which leads to apps being "re-installed" instead of updating.